### PR TITLE
Clean up directory structure and use more OTP semantics

### DIFF
--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -2,7 +2,6 @@ defmodule Butler do
   use Application
 
   def start(_type, _args) do
-    IO.puts "Starting"
     Butler.Supervisor.start_link
   end
 

--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -1,59 +1,12 @@
 defmodule Butler do
-  @slack_token Application.get_env(:slack, :api_key)
-  @user_agent [ {"User-agent", "Butler the slack bot"} ]
+  use Application
 
-  def main do
-    start_url
-    |> HTTPoison.get(@user_agent)
-    |> handle_response
-    |> extract_url
-    |> connect_to_socket
-    |> read_from_socket
+  def start(_type, _args) do
+    IO.puts "Starting"
+    Butler.Supervisor.start_link
   end
 
-  def start_url do
-    "https://slack.com/api/rtm.start?token=#{@slack_token}"
+  def stop(_) do
+    IO.puts "Cheerio"
   end
-
-  def handle_response({:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
-    body
-  end
-
-  def handle_response({:error, %HTTPoison.Error{reason: reason}}) do
-    IO.inspect reason
-    System.halt(2)
-  end
-
-  def extract_url(body) do
-    %{"url" => url } = Poison.Parser.parse! body
-    url
-  end
-
-  defp connect_to_socket(url) do
-    IO.puts "Connecting to #{url}"
-    Socket.connect!(url)
-  end
-
-  defp read_from_socket(socket) do
-    case Socket.Web.recv!(socket) do
-      { :text, resp } ->
-        IO.puts resp
-        resp |> Poison.Parser.parse! |> handle_slack_event(socket)
-      { :ping, _} ->
-        IO.puts "Ping"
-      { _, resp } ->
-        IO.puts "Unknown message: #{resp}"
-      _ ->
-        IO.puts "We're screwed"
-    end
-
-    read_from_socket(socket)
-  end
-
-  defp handle_slack_event(%{"type" => "message", "text" => text, "channel" => channel}, socket) do
-    IO.puts "Message in #{channel}: #{text}"
-    socket |> Socket.Web.send! { :text, ~s({"type": "message", "channel": "#{channel}", "text": "#{text} to you to"}) }
-  end
-
-  defp handle_slack_event(_, msg), do: msg
 end

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -1,0 +1,60 @@
+defmodule Butler.Bot do
+  use GenServer
+
+  def start_link(opts \\ []) do
+    {:ok, json} = Butler.Rtm.start
+
+    GenServer.start_link(__MODULE__, json, opts)
+  end
+
+  def init(json) do
+    IO.puts "init"
+    # IO.inspect json
+    # |> connect_to_socket
+    # |> read_from_socket
+    slack = %{
+      me: json.self,
+      team: json.team,
+      channels: json.channels,
+      groups: json.groups,
+      users: json.users
+    }
+
+    [user | rest ] = slack.users
+
+    IO.inspect user 
+    {:ok, slack}
+  end
+
+  def extract_url(body) do
+    IO.puts body
+  end
+
+  defp connect_to_socket(url) do
+    IO.puts "Connecting to #{url}"
+    Socket.connect!(url)
+  end
+
+  defp read_from_socket(socket) do
+    case Socket.Web.recv!(socket) do
+      { :text, resp } ->
+        IO.puts resp
+        resp |> Poison.Parser.parse! |> handle_slack_event(socket)
+      { :ping, _} ->
+        IO.puts "Ping"
+      { _, resp } ->
+        IO.puts "Unknown message: #{resp}"
+      _ ->
+        IO.puts "We're screwed"
+    end
+
+    read_from_socket(socket)
+  end
+
+  defp handle_slack_event(%{"type" => "message", "text" => text, "channel" => channel}, socket) do
+    IO.puts "Message in #{channel}: #{text}"
+    socket |> Socket.Web.send! { :text, ~s({"type": "message", "channel": "#{channel}", "text": "#{text} to you to"}) }
+  end
+
+  defp handle_slack_event(_, msg), do: msg
+end

--- a/lib/butler/rtm.ex
+++ b/lib/butler/rtm.ex
@@ -1,0 +1,19 @@
+defmodule Butler.Rtm do
+  @slack_token Application.get_env(:slack, :api_key)
+  @user_agent [ {"User-agent", "Butler the slack bot"} ]
+  @url "https://slack.com/api/rtm.start?token=#{@slack_token}"
+
+  def start do
+    HTTPoison.get(@url, @user_agent)
+    |> handle_response
+  end
+
+  defp handle_response({:ok, %HTTPoison.Response{body: body}}) do
+    json = Poison.Parser.parse!(body, keys: :atoms)
+    {:ok, json}
+  end
+
+  defp handle_response({:error, %HTTPoison.Error{reason: reason}}) do
+    {:error, reason}
+  end
+end

--- a/lib/butler/supervisor.ex
+++ b/lib/butler/supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Butler.Supervisor do
+  use Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok)
+  end
+
+  def init(:ok) do
+    children = [
+      worker(Butler.Bot, [[name: Butler.Bot]])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,8 +33,8 @@ defmodule Butler.Mixfile do
   defp deps do
     [
       {:poison, "~> 1.4.0"},
-      {:socket, "~> 0.3.0"},
-      {:httpoison, "~> 0.7"}
+      {:httpoison, "~> 0.7"},
+      {:websocket_client, github: "jeremyong/websocket_client"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,10 @@ defmodule Butler.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [ applications: [ :logger, :httpoison ] ]
+    [
+      applications: [ :logger, :httpoison ],
+      mod: {Butler, []}
+    ]
   end
 
   # Dependencies can be Hex packages:

--- a/mix.lock
+++ b/mix.lock
@@ -3,4 +3,5 @@
   "idna": {:hex, :idna, "1.0.2"},
   "poison": {:hex, :poison, "1.4.0"},
   "socket": {:hex, :socket, "0.3.0"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "websocket_client": {:git, "git://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []}}


### PR DESCRIPTION
TL;DR - I moved everything into standard mix application directory structure, swapped out the websocket client for the erlang version and Butler now responds when you say 'Hello Butler'

Now for the long version

Why:

We need a better way to manage the lifecycle of the bot that is more in line with OTP.  Also we want to allow users to easily start adding new handlers.

This change addresses the need by:

I've swapped out the old socket library for the erlang client.  In the future it would be great to use a pure elixir version but that version does not currently exist.  It might be something that we could write ourselves.  I've also added a very basic message handler so that Butler can respond to messages.  The handle message api isn't as friendly as it could be.  However, it allows for more flexibility when writing specific message handlers.  Once we have a feel for the handlers I'd like to try to create a more intuitive api (including regex parsing and not having to know as much about the underlying methodology).

We're capturing the initial slack org state when the bot starts up. However, we don't update that state based on any of the incoming slack messages.  Now that we have this skeleton in place we can start adding specific listeners to handle slack specific messages and use those messages to keep our internal state up to date.
