### PR TITLE
Adapters

### DIFF
--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -1,8 +1,8 @@
 defmodule Butler do
   use Application
 
-  def start(_type, plugins) do
-    Butler.Supervisor.start_link(plugins)
+  def start(_type, {adapter, plugins}) do
+    Butler.Supervisor.start_link(adapter, plugins)
   end
 
   def stop(_) do

--- a/lib/butler/adapter.ex
+++ b/lib/butler/adapter.ex
@@ -2,4 +2,9 @@ defmodule Adapter do
   use Behaviour
 
   defcallback hear()
+  defcallback emote()
+  defcallback reply()
+  defcallback topic()
+  defcallback run()
+  defcallback close
 end

--- a/lib/butler/adapter.ex
+++ b/lib/butler/adapter.ex
@@ -1,0 +1,5 @@
+defmodule Adapter do
+  use Behaviour
+
+  defcallback hear()
+end

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -21,7 +21,7 @@ defmodule Butler.Adapters.Console do
     format_reply({:text, msg})
   end
 
-  def format_reply({:code, msg}),  do: {:ok, "```#{msg}```"}
+  def format_reply({:code, msg}),  do: {:ok, "```\n#{msg}```"}
   def format_reply({:text, msg}),  do: {:ok, "#{msg}"}
   def format_reply({:quote, msg}), do: {:ok, ">#{msg}"}
   def format_reply(response), do: {:error, response}
@@ -36,7 +36,7 @@ defmodule Butler.Adapters.Console do
 
   defp print({:error, reponse}), do: Logger.error "Unknown response"
   defp print({:ok, output}) do
-    IO.puts output
+    IO.puts "\n#{output}"
   end
 
   def prompt do

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -1,6 +1,8 @@
 defmodule Butler.Adapters.Console do
   @name Application.get_env(:bot, :name)
 
+  require Logger
+
   def start_link do
     loop_acceptor
   end
@@ -11,6 +13,19 @@ defmodule Butler.Adapters.Console do
     loop_acceptor
   end
 
+  def reply(msg) do
+    msg |> format_reply |> print
+  end
+
+  def format_reply(msg) when is_binary(msg) do
+    format_reply({:text, msg})
+  end
+
+  def format_reply({:code, msg}),  do: {:ok, "```#{msg}```"}
+  def format_reply({:text, msg}),  do: {:ok, "#{msg}"}
+  def format_reply({:quote, msg}), do: {:ok, ">#{msg}"}
+  def format_reply(response), do: {:error, response}
+
   defp read do
     IO.gets prompt
   end
@@ -19,7 +34,8 @@ defmodule Butler.Adapters.Console do
     Butler.Bot.respond(msg)
   end
 
-  defp print(output) do
+  defp print({:error, reponse}), do: Logger.error "Unknown response"
+  defp print({:ok, output}) do
     IO.puts output
   end
 

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -1,0 +1,29 @@
+defmodule Butler.Adapters.Console do
+  @name Application.get_env(:bot, :name)
+
+  def start_link do
+    loop_acceptor
+  end
+
+  def loop_acceptor do
+    read |> evaluate
+
+    loop_acceptor
+  end
+
+  defp read do
+    IO.gets prompt
+  end
+
+  defp evaluate(msg) do
+    Butler.Bot.respond(msg)
+  end
+
+  defp print(output) do
+    IO.puts output
+  end
+
+  def prompt do
+    "#{@name}>"
+  end
+end

--- a/lib/butler/adapters/slack.ex
+++ b/lib/butler/adapters/slack.ex
@@ -53,6 +53,11 @@ defmodule Butler.Adapters.Slack do
     Poison.encode!(%{ type: "message", text: text, channel: channel })
   end
 
+  def send_message(text, channel, socket, client \\ :websocket_client) do
+    msg = Poison.encode!(%{ type: "message", text: text, channel: channel })
+    client.send({:text, msg}, socket)
+  end
+
   def send(text, channel, socket) do
     msg = Poison.encode!(%{ type: "message", text: text, channel: channel })
     :websocket_client.send({:text, msg}, socket)

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -1,12 +1,16 @@
 defmodule Butler.Bot do
   use GenServer
 
-  def start_link(adapter, events, plugins, opts \\ []) do
+  def start_link(adapter, events, plugins, _opts \\ []) do
     GenServer.start_link(__MODULE__, {adapter, events, plugins}, name: :bot)
   end
 
   def respond(msg) do
     GenServer.call(:bot, {:respond, msg})
+  end
+
+  def reply(msg) do
+    GenServer.call(:bot, {:reply, msg}) 
   end
 
   # Server callbacks
@@ -20,7 +24,13 @@ defmodule Butler.Bot do
   end
 
   def handle_call({:respond, msg}, _from, state) do
-    GenEvent.notify(state.events, {:message, msg, "", ""})
+    GenEvent.notify(state.events, {:message, msg})
     {:reply, msg, state}
   end
+
+  def handle_call({:reply, msg}, _from, state) do
+    state.adapter.reply(msg)
+    {:reply, {:ok, msg}, state}
+  end
 end
+

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -1,68 +1,26 @@
 defmodule Butler.Bot do
   use GenServer
 
-  def start_link(event_manager, plugins, opts \\ []) do
-    {:ok, json} = Butler.Rtm.start
-    url = String.to_char_list(json.url)
-    :websocket_client.start_link(url, __MODULE__, {json, event_manager, plugins})
+  def start_link(adapter, events, plugins, opts \\ []) do
+    GenServer.start_link(__MODULE__, {adapter, events, plugins}, name: :bot)
   end
 
-  def init({json, events, plugins}, socket) do
-    slack = %{
-      socket: socket,
-      me: json.self,
-      team: json.team,
-      channels: json.channels,
-      groups: json.groups,
-      users: json.users
-    }
+  def respond(msg) do
+    GenServer.call(:bot, {:respond, msg})
+  end
 
+  # Server callbacks
+
+  def init({adapter, events, plugins}) do
     Enum.each(plugins, fn({handler, state}) ->
       GenEvent.add_handler(events, handler, state)
     end)
 
-    {:ok, %{slack: slack, events: events}}
+    {:ok, %{adapter: adapter, plugins: plugins, events: events}}
   end
 
-  def websocket_info(:start, _connection, state) do
-    IO.puts "Starting"
-    {:ok, state}
-  end
-
-  def websocket_terminate(reason, _connection, state) do
-    IO.puts "Terminated"
-    IO.inspect reason
-    {:error, state}
-  end
-
-  def websocket_handle({:ping, msg}, _connection, state) do
-    IO.puts "Ping"
-    {:reply, {:pong, msg}, state}
-  end
-
-  def websocket_handle({:text, msg}, _connection, state) do
-    message = Poison.Parser.parse!(msg, keys: :atoms)
-    handle_message(message, state)
-  end
-
-  defp handle_message(message = %{type: "message", text: text}, state) do
-    IO.puts "incoming text #{text}"
-    GenEvent.notify(state.events, {:message, text, message.channel, state.slack})
-    {:ok, state}
-  end
-
-  defp handle_message(_message, state), do: {:ok, state}
-
-  defp encode(text, channel) do
-    Poison.encode!(%{ type: "message", text: text, channel: channel })
-  end
-
-  def send_message(text, channel, socket) do
-    msg = Poison.encode!(%{ type: "message", text: text, channel: channel })
-    :websocket_client.send({:text, msg}, socket)
-  end
-
-  def receive_message() do
-    GenEvent.notify(state.events, {:message, text, message.channel, state.slack})
+  def handle_call({:respond, msg}, _from, state) do
+    GenEvent.notify(state.events, {:message, msg, "", ""})
+    {:reply, msg, state}
   end
 end

--- a/lib/butler/logger.ex
+++ b/lib/butler/logger.ex
@@ -1,0 +1,12 @@
+defmodule Butler.Logger do
+  require Logger
+
+  def debug(msg) do
+    Logger.debug(msg)
+  end
+
+  def error(msg) do
+    Logger.error(msg)
+  end
+end
+

--- a/lib/butler/plugin.ex
+++ b/lib/butler/plugin.ex
@@ -10,31 +10,19 @@ defmodule Butler.Plugin do
 
       def handle_event({:message, text}, state) do
         if bot_mentioned?(text) do
-          parse_message(text) |> respond(state) |> handle_response(channel, slack)
+          strip_name(text)
+          |> respond(state)
+          |> handle_response
         else
-          hear(text, state) |> handle_response(channel, slack)
+          hear(text, state)
+          |> handle_response
         end
       end
 
-      defp handle_response({:noreply, state}, _channel, _slack), do: {:ok, state}
-
-      defp handle_response({:reply, response, state}, channel, slack) do
-        {:ok, msg} = response_message(response)
-        send_message(msg, channel, slack.socket)
+      defp handle_response({:noreply, state}), do: {:ok, state}
+      defp handle_response({:reply, response, state}) do
+        {:ok, response} = Butler.Bot.reply(response)
         {:ok, state}
-      end
-
-      def response_message(msg) when is_binary(msg) do
-        response_message({:text, msg})
-      end
-      def response_message({:code, msg}),  do: {:ok, "```#{msg}```"}
-      def response_message({:text, msg}),  do: {:ok, "#{msg}"}
-      def response_message({:quote, msg}), do: {:ok, ">#{msg}"}
-      def response_message(response) do
-        require Logger
-
-        Logger.error "Unknown response type"
-        {:error, response}
       end
 
       def bot_mentioned?(text) do
@@ -43,14 +31,9 @@ defmodule Butler.Plugin do
         first |> String.downcase |> String.contains?(name)
       end
 
-      def parse_message(text) do
+      def strip_name(text) do
         [_ | msg] = String.split(text)
         Enum.join(msg, " ")
-      end
-
-      def send_message(text, channel, socket, client \\ :websocket_client) do
-        msg = Poison.encode!(%{ type: "message", text: text, channel: channel })
-        client.send({:text, msg}, socket)
       end
     end
   end

--- a/lib/butler/plugin.ex
+++ b/lib/butler/plugin.ex
@@ -8,8 +8,7 @@ defmodule Butler.Plugin do
 
       @before_compile Butler.Plugin
 
-
-      def handle_event({:message, text, channel, slack}, state) do
+      def handle_event({:message, text}, state) do
         if bot_mentioned?(text) do
           parse_message(text) |> respond(state) |> handle_response(channel, slack)
         else
@@ -33,7 +32,7 @@ defmodule Butler.Plugin do
       def response_message({:quote, msg}), do: {:ok, ">#{msg}"}
       def response_message(response) do
         require Logger
-        
+
         Logger.error "Unknown response type"
         {:error, response}
       end

--- a/lib/butler/rtm.ex
+++ b/lib/butler/rtm.ex
@@ -1,4 +1,4 @@
-defmodule Butler.Rtm do
+defmodule Butler.Adapters.Slack.Rtm do
   @slack_token Application.get_env(:slack, :api_key)
   @user_agent [ {"User-agent", "Butler the slack bot"} ]
   @url "https://slack.com/api/rtm.start?token=#{@slack_token}"

--- a/lib/butler/supervisor.ex
+++ b/lib/butler/supervisor.ex
@@ -1,16 +1,17 @@
 defmodule Butler.Supervisor do
   use Supervisor
 
-  def start_link(plugins) do
-    Supervisor.start_link(__MODULE__, {:ok, plugins})
+  def start_link(adapter, plugins) do
+    Supervisor.start_link(__MODULE__, {:ok, adapter, plugins})
   end
 
   @manager_name Butler.EventManager
 
-  def init({:ok, plugins}) do
+  def init({:ok, adapter, plugins}) do
     children = [
       worker(GenEvent, [[name: @manager_name]]),
-      worker(Butler.Bot, [@manager_name, plugins, [name: Butler.Bot]])
+      worker(Butler.Bot, [adapter, @manager_name, plugins, []]),
+      worker(adapter, [])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -19,8 +19,12 @@ defmodule Butler.Mixfile do
   def application do
     [
       applications: [ :logger, :httpoison ],
-      mod: {Butler, plugins}
+      mod: {Butler, {adapter, plugins}}
     ]
+  end
+
+  def adapter do
+    Butler.Adapters.Console
   end
 
   def plugins do

--- a/test/butler/adapter_test.exs
+++ b/test/butler/adapter_test.exs
@@ -1,0 +1,13 @@
+defmodule Butler.AdapterTest do
+  use ExUnit.Case, async: true
+
+  test "run/1"
+  test "reply/1"
+  test "send/1"
+
+  test "sends messages to bot" do
+    adapter = TestAdapter.start_link
+    TestAdapter.send("This is a test")
+  end
+end
+

--- a/test/butler/adapters/console_test.exs
+++ b/test/butler/adapters/console_test.exs
@@ -1,0 +1,10 @@
+defmodule Butler.Adapters.ConsoleTest do
+  use ExUnit.Case
+
+  alias Butler.Adapters.Console, as: Console
+
+  test "it displays the bots name in the prompt" do
+    prompt = Console.prompt
+    assert prompt == "Butler>"
+  end
+end

--- a/test/butler/bot_test.exs
+++ b/test/butler/bot_test.exs
@@ -1,3 +1,19 @@
 defmodule Butler.BotTest do
   use ExUnit.Case, async: true
+
+  defmodule TestAdapter do
+    def start_link do
+    end
+  end
+
+  test "listens to messages through the adapter" do
+    adapter = TestAdapter.start_link
+    bot = Butler.Bot.start_link(adapter)
+    TestAdapter.received(adapter, "Hello World")
+  end
+
+  test "sends messages to plugins"
+  test "matches messages that start with the robots name"
+  test "does not match unaddressed messages"
+  test "receive/1 calls all registered plugins"
 end

--- a/test/butler_test.exs
+++ b/test/butler_test.exs
@@ -1,7 +1,4 @@
 defmodule ButlerTest do
   use ExUnit.Case
 
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
 end


### PR DESCRIPTION
# Why

There are currently 2 problems due to being tied to slack.

1) It makes it hard to do development
2) It means that if people aren't on slack then they have no use for Butler.
# Solution

My proposed solution for this problem involves refactoring all of the slack specific code into its own module. This can then be encapsulated as an "Adapter". This would allow anyone to create their own adapters for any protocol that we can target. It also allows us to build a "console" adapter that can read from a terminal. This would allow plugin writers and other people to do local development without having to run an instance of the chat platform.
## Architecture of adapters.

Adapters can run as their own process and be supervised by the `Butler.Supervisor`. This allows them to handle any implementation details internally (for instance slack needing to respond to frequent `pings`). We can then use a behaviour to ensure that all adapters implement the same public api.
## Control flow

Currently the main process is the bot process which runs the websocket connection. With the proposed changes the bot will become its own GenServer which can also be managed with `Butler.Supervisor`. The control flow then looks like this:

```
Adapter -> Bot -> GenEvent -----> Plugins

# Plugins can choose to respond or not. If they respond...

Plugins -> Bot -> Adapter
```

It could be argued that this makes the Bot a bottle neck in the system, however my thoughts on that are:

1) There is lots of munging of data and other filter that need to happen in the bot process.
2) Hiding the adapter implementation from plugins reduces their complexity
3) I'm just not that worried about a chat bots scalability
# Conclusion

This is still a work in progress. I've completed the initial console adapter but I haven't quite put the slack adapter back together. I would also like to figure out how to test each of these pieces before we move forward. I would really love any feedback or thoughts that you have.

What do y'all think?
