### PR TITLE
Move slack specific code to the bot module

### DIFF
--- a/lib/butler/message.ex
+++ b/lib/butler/message.ex
@@ -1,0 +1,9 @@
+defmodule Butler.Message do
+  defstruct type: "", text: "", user: "", channel: ""
+end
+
+defmodule Butler.Response do
+  @deriving [Poison.Encoder]
+  defstruct type: "message", text: "", channel: ""
+end
+


### PR DESCRIPTION
# Why:

We want to be able to support other adapters. This is a small step in that direction.
# This change addresses the need by:

I've moved all slack specific code from the plugin and module into the bot module. This is the most logical place to put it for now before we implement adapters properly. Doing this was somewhat tricky.
## Generic messages

Because the bot fires off events to the plugins we need some way to keep track of specific details about each message (user, channel, etc.). In order to do this I've created a new message struct that we can stuff information into. In the future if there is specific logic about these messages then we could define protocols around messages and allow new adapters to define their own message types. However, for now I'm keeping it simple and just building it for slack.
## Process registration:

In order to decouple the bot from each plugin the plugins need some way to send the adapter messages. However, this involves including the pid of the adapter process in the message, or registering the process with a name. While passing the pid around could work, it breaks supervision. For instance if the adapter process were to go down and be restarted with a new pid the message wouldn't be sent to the correct process.

I've opted to simply register the process name when the websocket client handler process starts. Unfortunately there is no way to simply pass a name to the client (ala. a GenSever) so we have to do this manually.

As always I would love the feedback. Let me know what you think.
