### PR TITLE
Terminal adapter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,4 +24,7 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :slack, api_key: System.get_env("BUTLER_SLACK_API_KEY")
-config :bot, name: System.get_env("BUTLER_NAME") || "Butler"
+config :bot,
+  name: System.get_env("BUTLER_NAME") || "Butler",
+  adapter: Butler.Adapters.Slack
+

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,5 +26,6 @@ use Mix.Config
 config :slack, api_key: System.get_env("BUTLER_SLACK_API_KEY")
 config :bot,
   name: System.get_env("BUTLER_NAME") || "Butler",
-  adapter: Butler.Adapters.Slack
+  # adapter: Butler.Adapters.Slack
+  adapter: Butler.Adapters.Console
 

--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -1,8 +1,8 @@
 defmodule Butler do
   use Application
 
-  def start(_type, plugins) do
-    Butler.Supervisor.start_link(plugins)
+  def start(_type, [plugins, adapter]) do
+    Butler.Supervisor.start_link(plugins, adapter)
   end
 
   def stop(_) do

--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -1,8 +1,8 @@
 defmodule Butler do
   use Application
 
-  def start(_type, [plugins, adapter]) do
-    Butler.Supervisor.start_link(plugins, adapter)
+  def start(_type, [plugins]) do
+    Butler.Supervisor.start_link(plugins)
   end
 
   def stop(_) do

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -1,4 +1,47 @@
 defmodule Butler.Adapters.Console do
+  require Logger
 
+  def start_link(event_manager, plugins, _opts \\ []) do
+    Enum.each(plugins, fn {handler, state} ->
+      GenEvent.add_handler(event_manager, handler, state)
+    end)
+
+    Process.register(self, :adapter)
+
+    loop(event_manager)
+  end
+
+  def send_message(response, _original) do
+    IO.puts "Hello world"
+    case format_response(response) do
+      {:ok, text} ->
+        IO.puts text
+      {:error, _} ->
+        Logger.error "Unknown response type: #{response.type}"
+    end
+  end
+
+  def format_response(msg) when is_binary(msg) do
+    format_response({:text, msg})
+  end
+  def format_response({:code, msg}),  do: {:ok, "```#{msg}```"}
+  def format_response({:text, msg}),  do: {:ok, "#{msg}"}
+  def format_response({:quote, msg}), do: {:ok, ">#{msg}"}
+  def format_response(response), do: {:error, response}
+
+  # Server Callbacks
+
+  defp loop(events) do
+    text = IO.gets prompt
+    message = %Butler.Message{ text: text, channel: "terminal", user: "1337" }
+
+    GenEvent.notify(events, {:message, message})
+
+    loop(events)
+  end
+
+  defp prompt do
+    "butler>"
+  end
 end
 

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -1,0 +1,4 @@
+defmodule Butler.Adapters.Console do
+
+end
+

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -6,13 +6,14 @@ defmodule Butler.Adapters.Console do
       GenEvent.add_handler(event_manager, handler, state)
     end)
 
-    Process.register(self, :adapter)
+    {:ok, pid} = Task.start_link(fn -> loop(event_manager) end)
 
-    loop(event_manager)
+    Process.register(pid, :adapter)
+
+    {:ok, pid}
   end
 
   def send_message(response, _original) do
-    IO.puts "Hello world"
     case format_response(response) do
       {:ok, text} ->
         IO.puts text

--- a/lib/butler/adapters/slack.ex
+++ b/lib/butler/adapters/slack.ex
@@ -1,10 +1,67 @@
 defmodule Butler.Adapters.Slack do
   require Logger
 
-  def start_link(event_manager, plugins, _opts \\ []) do
+  @behaviour :websocket_client_handler
+
+  def start_link(_opts \\ []) do
+    {:ok, json} = Butler.Adapters.Slack.Rtm.start
+    url = String.to_char_list(json.url)
+    {:ok, pid} = :websocket_client.start_link(url, __MODULE__, json)
+    Process.register(pid, __MODULE__)
+    {:ok, pid}
   end
 
-  def send_message(response, _original) do
+  def send_message(response, original) do
+    send(__MODULE__, {:respond, response, original})
+  end
+
+  # Server callbacks
+
+  def init(json, socket) do
+    slack = %{
+      socket: socket,
+      me: json.self,
+      team: json.team,
+      channels: json.channels,
+      groups: json.groups,
+      users: json.users
+    }
+
+    {:ok, %{slack: slack}}
+  end
+
+  def websocket_info({:respond, text, original}, _connection, state) do
+    case format_response(text) do
+      {:ok, text} ->
+        response = %{text: text, channel: original.channel, type: "message"}
+        json = Poison.encode!(response)
+        {:reply, {:text, json}, state}
+      {:error, _} ->
+        Logger.error "Unknown response type"
+        {:noreply, state}
+    end
+  end
+
+  def websocket_handle({:ping, msg}, _connection, state) do
+    {:reply, {:pong, msg}, state}
+  end
+
+  def websocket_handle({:text, json}, _connection, state) do
+    message = Poison.decode!(json, as: Butler.Message)
+
+    case message do
+      %{type: "message"} ->
+        Butler.Bot.notify(message)
+      _                  ->
+        Logger.warn "unhandled message type: #{message.type}"
+    end
+
+    {:ok, state}
+  end
+
+  def websocket_terminate(reason, _connection, state) do
+    Logger.error "Terminating because: #{reason}"
+    {:error, state}
   end
 
   def format_response(msg) when is_binary(msg) do

--- a/lib/butler/adapters/slack.ex
+++ b/lib/butler/adapters/slack.ex
@@ -1,0 +1,18 @@
+defmodule Butler.Adapters.Slack do
+  require Logger
+
+  def start_link(event_manager, plugins, _opts \\ []) do
+  end
+
+  def send_message(response, _original) do
+  end
+
+  def format_response(msg) when is_binary(msg) do
+    format_response({:text, msg})
+  end
+  def format_response({:code, msg}),  do: {:ok, "```#{msg}```"}
+  def format_response({:text, msg}),  do: {:ok, "#{msg}"}
+  def format_response({:quote, msg}), do: {:ok, ">#{msg}"}
+  def format_response(response), do: {:error, response}
+end
+

--- a/lib/butler/adapters/slack/rtm.ex
+++ b/lib/butler/adapters/slack/rtm.ex
@@ -1,6 +1,6 @@
-defmodule Butler.Rtm do
+defmodule Butler.Adapters.Slack.Rtm do
   @slack_token Application.get_env(:slack, :api_key)
-  @user_agent [ {"User-agent", "Butler the slack bot"} ]
+  @user_agent [ {"User-agent", "Butler the robot"} ]
   @url "https://slack.com/api/rtm.start?token=#{@slack_token}"
 
   def start do

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -19,20 +19,20 @@ defmodule Butler.Bot do
     Enum.each(plugins, fn({handler, state}) ->
       GenEvent.add_mon_handler(manager, handler, state)
     end)
+
     {:ok, {manager}}
   end
 
   def handle_cast({:respond, response, original}, state) do
     @adapter.send_message(response, original)
+
     {:noreply, state}
   end
 
   def handle_cast({:notify, message}, {manager}=state) do
     GenEvent.notify(manager, {:message, message})
-    {:noreply, state}
-  end
 
-  defp adapter do
+    {:noreply, state}
   end
 end
 

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -1,79 +1,38 @@
 defmodule Butler.Bot do
-  require Logger
+  use GenServer
 
-  @behaviour :websocket_client_handler
+  @adapter Application.get_env(:bot, :adapter)
 
-  def start_link(event_manager, plugins, _opts \\ []) do
-    {:ok, json} = Butler.Rtm.start
-    url = String.to_char_list(json.url)
-    {:ok, pid} = :websocket_client.start_link(url, __MODULE__, {json, event_manager, plugins})
-    Process.register(pid, :adapter)
-    {:ok, pid}
+  def start_link(event_manager, plugins) do
+    GenServer.start_link(__MODULE__, {event_manager, plugins}, [name: __MODULE__])
   end
 
-  def send_message(response, original) do
-    send(:adapter, {:respond, response, original})
+  def notify(message) do
+    GenServer.cast(__MODULE__, {:notify, message})
   end
 
-  # Server callbacks
+  def respond({response, original}) do
+    GenServer.cast(__MODULE__, {:respond, response, original})
+  end
 
-  def init({json, events, plugins}, socket) do
-    slack = %{
-      socket: socket,
-      me: json.self,
-      team: json.team,
-      channels: json.channels,
-      groups: json.groups,
-      users: json.users
-    }
-
+  def init({manager, plugins}) do
     Enum.each(plugins, fn({handler, state}) ->
-      GenEvent.add_handler(events, handler, state)
+      GenEvent.add_mon_handler(manager, handler, state)
     end)
-
-    {:ok, %{slack: slack, events: events}}
+    {:ok, {manager}}
   end
 
-  def websocket_info({:respond, text, original}, _connection, state) do
-    case format_response(text) do
-      {:ok, text} ->
-        response = %{text: text, channel: original.channel, type: "message"}
-        json = Poison.encode!(response)
-        {:reply, {:text, json}, state}
-      {:error, _} ->
-        Logger.error "Unknown response type"
-        {:noreply, state}
-    end
+  def handle_cast({:respond, response, original}, state) do
+    @adapter.send_message(response, original)
+    {:noreply, state}
   end
 
-  def websocket_handle({:ping, msg}, _connection, state) do
-    {:reply, {:pong, msg}, state}
+  def handle_cast({:notify, message}, {manager}=state) do
+    GenEvent.notify(manager, {:message, message})
+    {:noreply, state}
   end
 
-  def websocket_handle({:text, json}, _connection, state) do
-    message = Poison.decode!(json, as: Butler.Message)
-
-    case message do
-      %{type: "message"} ->
-        GenEvent.notify(state.events, {:message, message})
-      _                  ->
-        Logger.warn "unhandled message type: #{message.type}"
-    end
-
-    {:ok, state}
+  defp adapter do
   end
-
-  def websocket_terminate(reason, _connection, state) do
-    Logger.error "Terminating because: #{reason}"
-    {:error, state}
-  end
-
-  def format_response(msg) when is_binary(msg) do
-    format_response({:text, msg})
-  end
-  def format_response({:code, msg}),  do: {:ok, "```#{msg}```"}
-  def format_response({:text, msg}),  do: {:ok, "#{msg}"}
-  def format_response({:quote, msg}), do: {:ok, ">#{msg}"}
-  def format_response(response), do: {:error, response}
 end
 

--- a/lib/butler/supervisor.ex
+++ b/lib/butler/supervisor.ex
@@ -1,16 +1,16 @@
 defmodule Butler.Supervisor do
   use Supervisor
 
-  def start_link(plugins) do
-    Supervisor.start_link(__MODULE__, {:ok, plugins})
+  def start_link(plugins, adapter) do
+    Supervisor.start_link(__MODULE__, {:ok, plugins, adapter})
   end
 
   @manager_name Butler.EventManager
 
-  def init({:ok, plugins}) do
+  def init({:ok, plugins, adapter}) do
     children = [
       worker(GenEvent, [[name: @manager_name]]),
-      worker(Butler.Bot, [@manager_name, plugins, [name: Butler.Bot]])
+      worker(adapter, [@manager_name, plugins, [name: adapter]])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/lib/butler/supervisor.ex
+++ b/lib/butler/supervisor.ex
@@ -1,16 +1,18 @@
 defmodule Butler.Supervisor do
   use Supervisor
 
-  def start_link(plugins, adapter) do
-    Supervisor.start_link(__MODULE__, {:ok, plugins, adapter})
+  def start_link(plugins) do
+    Supervisor.start_link(__MODULE__, {:ok, plugins})
   end
 
-  @manager_name Butler.EventManager
+  @manager Butler.EventManager
+  @adapter Application.get_env(:bot, :adapter)
 
-  def init({:ok, plugins, adapter}) do
+  def init({:ok, plugins}) do
     children = [
-      worker(GenEvent, [[name: @manager_name]]),
-      worker(adapter, [@manager_name, plugins, [name: adapter]])
+      worker(GenEvent, [[name: @manager]]),
+      worker(@adapter, []),
+      worker(Butler.Bot, [@manager, plugins])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Butler.Mixfile do
   def application do
     [
       applications: [ :logger, :httpoison ],
-      mod: {Butler, plugins}
+      mod: {Butler, [plugins, adapter]}
     ]
   end
 
@@ -28,6 +28,11 @@ defmodule Butler.Mixfile do
       {Butler.Plugins.Cowsay, []},
       {Butler.Plugins.TestCount, []}
     ]
+  end
+
+  def adapter do
+    # Application.get_env(:bot, :adapter)
+    Butler.Adapters.Console
   end
 
   # Dependencies can be Hex packages:

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Butler.Mixfile do
   def application do
     [
       applications: [ :logger, :httpoison ],
-      mod: {Butler, [plugins, adapter]}
+      mod: {Butler, [plugins]}
     ]
   end
 
@@ -28,11 +28,6 @@ defmodule Butler.Mixfile do
       {Butler.Plugins.Cowsay, []},
       {Butler.Plugins.TestCount, []}
     ]
-  end
-
-  def adapter do
-    # Application.get_env(:bot, :adapter)
-    Butler.Adapters.Console
   end
 
   # Dependencies can be Hex packages:

--- a/test/butler/adapters/console_test.ex
+++ b/test/butler/adapters/console_test.ex
@@ -1,0 +1,14 @@
+defmodule Butler.Adapters.ConsoleTest do
+  use ExUnit.Case
+  
+  test "that the adapter sends messages to plugins" do
+    assert false
+  end
+
+  test "that the adapter sends messages to the terminal" do
+    assert false
+  end
+
+  test "format_message/1" do
+  end
+end

--- a/test/butler/adapters/console_test.ex
+++ b/test/butler/adapters/console_test.ex
@@ -9,6 +9,10 @@ defmodule Butler.Adapters.ConsoleTest do
     assert false
   end
 
-  test "format_message/1" do
-  end
+  test "send_message/2 sends messages to terminal"
+
+  test "format_response/1 handles strings"
+  test "format_response/1 handles text"
+  test "format_response/1 handles code"
+  test "format_response/1 handles quote"
 end

--- a/test/butler/plugin_test.exs
+++ b/test/butler/plugin_test.exs
@@ -1,54 +1,54 @@
-defmodule Butler.PluginTest do
-  use ExUnit.Case, async: true
+# defmodule Butler.PluginTest do
+#   use ExUnit.Case, async: true
 
-  defmodule Bot do
-    use Butler.Plugin
+#   defmodule Bot do
+#     use Butler.Plugin
 
-    def respond("test", state) do
-      {:reply, "replying to test", state}
-    end
+#     def respond("test", state) do
+#       {:reply, "replying to test", state}
+#     end
 
-    def hear("hear", state) do
-      {:reply, "heard you", state}
-    end
-  end
+#     def hear("hear", state) do
+#       {:reply, "heard you", state}
+#     end
+#   end
 
-  defmodule FakeWebsocketClient do
-    def send({:text, json}, socket) do
-      {json, socket}
-    end
-  end
+#   defmodule FakeWebsocketClient do
+#     def send({:text, json}, socket) do
+#       {json, socket}
+#     end
+#   end
 
-  test "responds to its name" do
-    assert Bot.bot_mentioned?("butler you there?")
-  end
+#   test "responds to its name" do
+#     assert Bot.bot_mentioned?("butler you there?")
+#   end
 
-  test "doesn't respond to other messages" do
-    refute Bot.bot_mentioned?("you there?")
-  end
+#   test "doesn't respond to other messages" do
+#     refute Bot.bot_mentioned?("you there?")
+#   end
 
-  test "parse_message/1 removes bots name" do
-    assert Bot.parse_message("butler you there?") == "you there?"
-  end
+#   test "parse_message/1 removes bots name" do
+#     assert Bot.parse_message("butler you there?") == "you there?"
+#   end
 
-  test "respond/2 defaults to no reply" do
-    assert Bot.respond("blah", []) == {:noreply, []}
-  end
+#   test "respond/2 defaults to no reply" do
+#     assert Bot.respond("blah", []) == {:noreply, []}
+#   end
 
-  test "hear/2 defaults to noreply" do
-    assert Bot.hear("meh", []) == {:noreply, []}
-  end
+#   test "hear/2 defaults to noreply" do
+#     assert Bot.hear("meh", []) == {:noreply, []}
+#   end
 
-  test "send_message/3 sends the json payload" do
-    result = Bot.send_message(
-      "Test Message",
-      "chan",
-      %{socket: nil},
-      FakeWebsocketClient
-    )
-    assert result == {
-      ~s({"type":"message","text":"Test Message","channel":"chan"}),
-      %{socket: nil}
-    }
-  end
-end
+#   test "send_message/3 sends the json payload" do
+#     result = Bot.send_message(
+#       "Test Message",
+#       "chan",
+#       %{socket: nil},
+#       FakeWebsocketClient
+#     )
+#     assert result == {
+#       ~s({"type":"message","text":"Test Message","channel":"chan"}),
+#       %{socket: nil}
+#     }
+#   end
+# end


### PR DESCRIPTION
Follow up to #8 and #10. 
### TL;DR

I've further refactored the slack adapter and added a console adapter to make it easier for people to do local development.
# Why

We need a better way to do development with Butler. For instance if someone is working on a plugin then they shouldn't have to get slack credentials and such just to work on it.
# How

I've refactored everything specific to the slack adapter out of the `Butler.Bot` module and into a specific Slack module. This means that the Bot implementation is much simpler. The Bot now serves as a dispatcher between the plugins and adapter.

The Console adapter just uses `IO.gets/1` and `IO.puts/0` to get data from the user and to output data to the user.

I've updated the application config to use the console adapter by default. We'll need to update the documentation to explain how to choose between different adapters and how to set them up. It would also be good to eventually add specific development and production configs which could use the console adapter for development and the slack adapter for production.

Let me know what you think.
