### PR TITLE
Generate a new Butler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,8 +24,7 @@ use Mix.Config
 #     import_config "#{Mix.env}.exs"
 
 config :butler,
-  api_key: System.get_env("BUTLER_SLACK_API_KEY"),
   name: System.get_env("BUTLER_NAME") || "Butler",
-  # adapter: Butler.Adapters.Slack
-  adapter: Butler.Adapters.Console
+  adapter: Butler.Adapters.Console,
+  plugins: []
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,3 @@
+# mix butler.new
+
+Provides an archive to generate a new butler application.

--- a/generator/lib/butler_new.ex
+++ b/generator/lib/butler_new.ex
@@ -1,0 +1,71 @@
+defmodule Mix.Tasks.Butler.New do
+  use Mix.Task
+  import Mix.Generator
+
+  @version Mix.Project.config[:version]
+  @shortdoc "Create a new Butler application"
+
+  @new_files ~w(
+    README.md
+    mix.exs
+    .gitignore
+    plugins/example.ex
+    config/config.exs
+    config/dev.exs
+    config/prod.exs
+  )
+
+  @moduledoc """
+  Creates a new Butler application.
+
+      mix butler.new PATH
+
+  A robot will be created at the given PATH.
+  """
+  def run([version]) when version in ~w(-v --version) do
+    Mix.shell.info "Butler v#{@version}"
+  end
+
+  def run(argv) do
+    case argv do
+      [] ->
+        Mix.raise "Expected PATH to be given, `mix butler.new PATH`"
+      [path|_] ->
+        app_name = path |> Path.expand |> Path.basename
+        mod_name = app_name |> Mix.Utils.camelize
+        run(path, app_name, mod_name)
+    end
+  end
+
+  def run(path, app_name, mod_name) do
+    bindings = [mod_name: mod_name, app_name: app_name, version: @version]
+    create_directory(path)
+    create_files(path, bindings)
+    print_info(path)
+  end
+
+  defp create_files(path, bindings) do
+    for file <- @new_files do
+      contents = rendered_template(file, bindings)
+      new_file = Path.join(path, file)
+      create_file(new_file, contents)
+    end
+  end
+
+  defp rendered_template(file, bindings) do
+    EEx.eval_file "templates/new/#{file}", bindings
+  end
+
+  defp print_info(path) do
+    Mix.shell.info """
+
+    Your Butler has been installed. Run it with:
+
+        $ cd #{path}
+        $ mix deps.get
+        $ mix run --no-halt
+
+    Enjoy your new Robot!
+    """
+  end
+end

--- a/generator/mix.exs
+++ b/generator/mix.exs
@@ -1,0 +1,15 @@
+defmodule Butler.New.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :butler_new,
+      version: "0.3.0",
+      elixir: "~> 1.1.0"
+    ]
+  end
+
+  def application do
+    [applications: []]
+  end
+end

--- a/generator/templates/new/.gitignore
+++ b/generator/templates/new/.gitignore
@@ -3,5 +3,3 @@
 erl_crash.dump
 *.ez
 .env
-/generator/_build
-.DS_Store

--- a/generator/templates/new/README.md
+++ b/generator/templates/new/README.md
@@ -1,0 +1,38 @@
+# <%= mod_name %>
+
+<%= mod_name %> is a bot built with Butler.
+
+## Running <%= mod_name %> locally
+
+You may need to run <%= mod_name %> locally in order to develop plugins and test new features.
+The Butler framework provides a repl that can be used for local development.
+
+Starting <%= mod_name %> is easy:
+
+    $ mix run --no-halt
+
+You can then run commands:
+
+    <%= app_name %>><%= app_name %> example
+    This is an example response
+    <%= app_name %>>
+
+## Configuration
+
+TODO - Add more content here
+
+## Plugins
+
+TODO - Add information about adding plugins to the bot
+
+### External Plugins
+
+### Writing your own plugins
+
+## Adapters
+
+TODO - Give an example of how to use adapters
+
+## Deployment
+
+TODO - lolkthnxbye

--- a/generator/templates/new/config/config.exs
+++ b/generator/templates/new/config/config.exs
@@ -1,0 +1,10 @@
+use Mix.Config
+
+config :butler,
+  name: System.get_env("BUTLER_NAME") || "<%= app_name %>",
+  adapter: Butler.Adapters.Console,
+  plugins: [
+    {<%= mod_name %>.Example, []}
+  ]
+
+import_config "#{Mix.env}.exs"

--- a/generator/templates/new/config/dev.exs
+++ b/generator/templates/new/config/dev.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :butler,
+  adapter: Butler.Adapters.Console
+

--- a/generator/templates/new/config/prod.exs
+++ b/generator/templates/new/config/prod.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :bot,
+  adapter: Butler.Adapters.Slack
+

--- a/generator/templates/new/mix.exs
+++ b/generator/templates/new/mix.exs
@@ -1,0 +1,37 @@
+defmodule <%= mod_name %>.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :<%= app_name %>,
+     version: "0.0.1",
+     elixir: "~> 1.0",
+     elixirc_paths: elixirc_paths(Mix.env),
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type `mix help compile.app` for more information
+  def application do
+    [
+      applications: [:logger, :butler]
+    ]
+  end
+
+  def elixirc_paths(_), do: ["plugins"]
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type `mix help deps` for more examples and options
+  defp deps do
+    [{:butler, "~> <%= version %>"}]
+  end
+end

--- a/generator/templates/new/plugins/example.ex
+++ b/generator/templates/new/plugins/example.ex
@@ -1,0 +1,8 @@
+defmodule <%= mod_name %>.Example do
+  use Butler.Plugin
+
+  # TODO - Add some comments with examples of how to bulid plugins
+  def respond("example me", state) do
+    {:reply, "This is an example response", state}
+  end
+end

--- a/lib/butler.ex
+++ b/lib/butler.ex
@@ -47,8 +47,8 @@ defmodule Butler do
   @doc """
   Starts Butler.
   """
-  def start(_type, [plugins]) do
-    Butler.Supervisor.start_link(plugins)
+  def start(_type, _opts \\ []) do
+    Butler.Supervisor.start_link()
   end
 
   @doc """

--- a/lib/butler/adapters/console.ex
+++ b/lib/butler/adapters/console.ex
@@ -1,6 +1,8 @@
 defmodule Butler.Adapters.Console do
   require Logger
 
+  @bot_name Application.get_env(:butler, :name)
+
   def start_link(_opts \\ []) do
     import Supervisor.Spec
 
@@ -45,7 +47,7 @@ defmodule Butler.Adapters.Console do
   end
 
   defp prompt do
-    "butler>"
+    "#{@bot_name}>"
   end
 end
 

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -2,9 +2,10 @@ defmodule Butler.Bot do
   use GenServer
 
   @adapter Application.get_env(:butler, :adapter)
+  @plugins Application.get_env(:butler, :plugins)
 
-  def start_link(event_manager, plugins) do
-    GenServer.start_link(__MODULE__, {event_manager, plugins}, [name: __MODULE__])
+  def start_link(event_manager) do
+    GenServer.start_link(__MODULE__, {event_manager}, [name: __MODULE__])
   end
 
   def notify(message) do
@@ -15,8 +16,8 @@ defmodule Butler.Bot do
     GenServer.cast(__MODULE__, {:respond, response, original})
   end
 
-  def init({manager, plugins}) do
-    Enum.each(plugins, fn({handler, state}) ->
+  def init({manager}) do
+    Enum.each(@plugins, fn({handler, state}) ->
       GenEvent.add_mon_handler(manager, handler, state)
     end)
 

--- a/lib/butler/supervisor.ex
+++ b/lib/butler/supervisor.ex
@@ -1,18 +1,18 @@
 defmodule Butler.Supervisor do
   use Supervisor
 
-  def start_link(plugins) do
-    Supervisor.start_link(__MODULE__, {:ok, plugins})
+  def start_link() do
+    Supervisor.start_link(__MODULE__, {:ok})
   end
 
   @manager Butler.EventManager
   @adapter Application.get_env(:butler, :adapter)
 
-  def init({:ok, plugins}) do
+  def init({:ok}) do
     children = [
       worker(GenEvent, [[name: @manager]]),
       worker(@adapter, []),
-      worker(Butler.Bot, [@manager, plugins])
+      worker(Butler.Bot, [@manager])
     ]
 
     supervise(children, strategy: :one_for_one)


### PR DESCRIPTION
## Why

Users need to be able to generate their own versions of Butler
## How

This change allows us to create new versions of Butler for users with the use of an archive application and mix task.

The mix task creates an empty application that loads Butler as a dependency. Users can then install plugins from hex or include their own plugins in the plugins directory. Users can also configure their own Butler from the separate configuration files we include. In the future I would like to avoid having to create a list of plugins, or automatically load plugins from the `plugins` directory. However, I'm not sure what the ideal interface looks like yet so for now we're just using the configuration.
