### PR TITLE
Plugins now reference the bot module which returns a default name

### DIFF
--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -1,24 +1,30 @@
 defmodule Butler.Bot do
-  @adapter Application.get_env(:butler, :adapter)
-
   def notify(msg) do
     plugins
     |> Enum.each(fn(plugin) -> notify_plugin(plugin, msg) end)
   end
 
   def reply(resp) do
-    @adapter.reply(resp)
+    adapter.reply(resp)
   end
 
   def say(resp) do
-    @adapter.say(resp)
+    adapter.say(resp)
+  end
+
+  def name do
+    Application.get_env(:butler, :name) || "butler"
+  end
+
+  def plugins do
+    Application.get_env(:butler, :plugins)
+  end
+
+  def adapter do
+    Application.get_env(:butler, :adapter)
   end
 
   defp notify_plugin({plugin, _opts}, msg) do
     Task.Supervisor.start_child(Butler.PluginSupervisor, plugin, :notify, [msg])
-  end
-
-  defp plugins do
-    Application.get_env(:butler, :plugins)
   end
 end

--- a/lib/butler/plugin.ex
+++ b/lib/butler/plugin.ex
@@ -104,7 +104,7 @@ defmodule Butler.Plugin do
   end
 
   defp bots_name do
-    Application.get_env(:butler, :name)
+    Butler.Bot.name
   end
 
   defp bots_name_regex do


### PR DESCRIPTION
In order to write plugins developers currently have to include a configuration value just to get butler the butler dependency to compile. This is obviously not ideal and the configuration won't do anything anyway since it'll get overwritten the plugin is included in a different project. This should fix the issue.

I've also changed the way that we reference the adapter to match the way that we reference plugins to avoid any future issues with changing the adapter configuration.
