### PR TITLE
Add a basic help plugin and expose "usage" for each handler in a plugin.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,7 @@ config :butler,
   name: System.get_env("BUTLER_NAME") || "Butler",
   adapter: Butler.Adapters.Console,
   plugins: [
+    {Butler.Plugins.Help, []},
     {Butler.Plugins.TestCount, []}
   ]
 

--- a/generator/templates/new/config/config.exs
+++ b/generator/templates/new/config/config.exs
@@ -4,6 +4,7 @@ config :butler,
   name: System.get_env("BUTLER_NAME") || "<%= app_name %>",
   adapter: Butler.Adapters.Console,
   plugins: [
+    {Butler.Plugins.Help, []},
     {<%= mod_name %>.Example, []}
   ]
 

--- a/lib/butler/bot.ex
+++ b/lib/butler/bot.ex
@@ -17,7 +17,7 @@ defmodule Butler.Bot do
   end
 
   def plugins do
-    Application.get_env(:butler, :plugins)
+    Application.get_env(:butler, :plugins) || []
   end
 
   def adapter do

--- a/lib/butler/plugin.ex
+++ b/lib/butler/plugin.ex
@@ -11,6 +11,7 @@ defmodule Butler.Plugin do
 
       Module.register_attribute __MODULE__, :responders, accumulate: true
       Module.register_attribute __MODULE__, :hearers, accumulate: true
+      Module.register_attribute __MODULE__, :usage, accumulate: true
 
       @before_compile unquote(__MODULE__)
 
@@ -22,6 +23,12 @@ defmodule Butler.Plugin do
 
   defmacro __before_compile__(_env) do
     quote do
+      def usage do
+        @usage
+        |> Enum.map(fn(usage) -> usage end)
+        |> Enum.reverse
+      end
+
       def notify(msg) do
         if handler = find_handler(msg) do
           call_plugin(handler, msg)

--- a/lib/butler/plugins/help.ex
+++ b/lib/butler/plugins/help.ex
@@ -1,0 +1,20 @@
+defmodule Butler.Plugins.Help do
+  @moduledoc """
+  Replies with a list of usages for all of the installed plugins.
+  """
+
+  use Butler.Plugin
+
+  @usage """
+  butler help - Returns the helps messages for all the installed plugins
+  """
+  respond ~r/help/, conn do
+    usages =
+      Butler.Bot.plugins
+      |> Enum.map(fn({plugin, _opts}) -> plugin end)
+      |> Enum.flat_map(fn(plugin) -> plugin.usage end)
+      |> Enum.join
+
+    reply conn, code(usages)
+  end
+end

--- a/lib/butler/plugins/test_count.ex
+++ b/lib/butler/plugins/test_count.ex
@@ -1,12 +1,21 @@
 defmodule Butler.Plugins.TestCount do
+  @moduledoc """
+  Keeps track of the number of times 'test' has been said in chat.
+  """
   use Butler.Plugin
 
+  @usage """
+  butler test count - Returns the number of times 'test' has been said
+  """
   respond ~r/test count/, conn do
     # count = Enum.count(tests)
     count = 3
     reply conn, "The count is #{count}"
   end
 
+  @usage """
+  test - Increments the count
+  """
   hear ~r/test/, conn do
     # ["test"|tests]
     say conn, "I heard some tests"


### PR DESCRIPTION
Users can now declare a `@usage` for each handler in their plugin. A `help` plugin pulls each usage for every plugin installed and returns it to the user formatted as code.

I've also updated the template to include the help plugin by default.
